### PR TITLE
LPD-98469 Remove prose hyphen from site initializer rules comment

### DIFF
--- a/workspaces/liferay-sample-workspace/.workspace-rules/rules/site-initializer-format.md
+++ b/workspaces/liferay-sample-workspace/.workspace-rules/rules/site-initializer-format.md
@@ -81,7 +81,7 @@ client-extensions/<name>/
           page-definition.json
           master-page.json       # {"name": ...} — NOT page-template.json
           thumbnail.png          # optional
-    layout-set/                   # Site-wide navigation and theme settings
+    layout-set/                   # Site wide navigation and theme settings
       public/
         metadata.json
     layouts/                      # Site pages


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98469

## What Is Being Fixed

The site initializer format reference card carried a hyphenated compound modifier ("Site-wide") in a directory-tree comment, which conflicts with Liferay's prose convention (rule 701: avoid hyphens in prose).

## How It Is Being Fixed

Changed "Site-wide" to "Site wide" in the `layout-set/` comment of `.workspace-rules/rules/site-initializer-format.md`. The sibling `.claude`, `.github`, and `.cursor` copies are symlinks to this canonical file, so they pick up the change automatically.

## Why Are There No Tests?

Documentation-only change — a single-word wording fix in a Markdown reference card, with no code to exercise.

## PR Check

**pr-check: PASS** — tested on `81f11e074618c3cb0398cd1f8699dd1f5ebd3808`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "81f11e074618c3cb0398cd1f8699dd1f5ebd3808"} -->
