### PR TITLE
LPD-98467 Allow manual dispatch of evergreen publish job

### DIFF
--- a/.github/workflows/ci-publish-liferay-sample-workspace-evergreen.yaml
+++ b/.github/workflows/ci-publish-liferay-sample-workspace-evergreen.yaml
@@ -16,3 +16,4 @@ on:
             -   workspaces/liferay-sample-workspace/.gemini/**
             -   workspaces/liferay-sample-workspace/.windsurf/**
             -   workspaces/liferay-sample-workspace/.workspace-rules/**
+    workflow_dispatch:


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98467

## What Is Being Fixed

The workflow that publishes the sample workspace evergreen artifact only ran on pushes to master that touched the workspace files. There was no way to publish the artifact on demand.

## How It Is Being Fixed

Added a `workflow_dispatch` trigger alongside the existing `push` trigger, so the job can be run manually from the Actions tab while still running automatically on qualifying pushes.

## Why Are There No Tests?

The change only adds a `workflow_dispatch` trigger to a GitHub Actions workflow. There is no runtime code path to exercise, and workflow triggers are not covered by any of the repository's test layers.

## PR Check

**pr-check: PASS** — tested on `93effd8ccbc060dcc363e8fe2ca9e2bade973083`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Structural Smoke | PASS |

<!-- pr-check {"result": "success", "sha": "93effd8ccbc060dcc363e8fe2ca9e2bade973083"} -->
